### PR TITLE
Updated bourbon path in gruntfile.js

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
 					destPrefix: 'assets/scss/vendor'
 				},
 				files: {
-					'bourbon': 'bourbon/dist',
+					'bourbon': 'bourbon/app/assets/stylesheets',
 					'neat': 'neat/app/assets/stylesheets',
 				}
 			}


### PR DESCRIPTION
After installing bower and running bower install neat and bower install
bourbon I got an error while running grunt. Debugging the issue made me
realize the location of the style sheets have been updated with the
latest version of bourbon. Grunt ran successfully after.
